### PR TITLE
1.1.0

### DIFF
--- a/defended/bd/bd.yr
+++ b/defended/bd/bd.yr
@@ -33,11 +33,11 @@ rule bd_php_eval_gz_b64_0 {
     $s1
 }
 
-rule bd_php_sglobals_stream_0 {
+rule bd_php_rce_stream_sglobal_0 {
   meta:
     author = "roscoe skeens (defended.net)"
     license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
-    description = "super globals stream"
+    description = "rce stream sglobal"
 
   strings:
     $s1 = "$_GET"
@@ -48,11 +48,11 @@ rule bd_php_sglobals_stream_0 {
     all of them
 }
 
-rule bd_php_sglobals_assert_0 {
+rule bd_php_rce_assert_sglobal_0 {
   meta:
     author = "roscoe skeens (defended.net)"
     license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
-    description = "super globals assert"
+    description = "rce assert sglobal"
 
   strings:
     $h1 = { 61 73 73 65 72 74 [0-10] 28 [0-10] 24 5F }
@@ -61,11 +61,38 @@ rule bd_php_sglobals_assert_0 {
     $h1
 }
 
-rule bd_php_callback_xpath_0 {
+rule bd_php_rce_cback_sglobal_0 {
   meta:
     author = "roscoe skeens (defended.net)"
     license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
-    description = "callback xpath"
+    description = "rce cback sglobal"
+
+  strings:
+    $r1 = /(array_(filter|walk|udiff)|(u|ua|uk)sort)[ \t]{,8}\([ \t]{,8}\[\$(GLOBALS|_)/
+    $r2 = /(call_user_func|register_shutdown_function)[ \t]{,8}\(.{1,16}\[?\$(GLOBALS|_)[CFGPRS]/
+
+  condition:
+    any of them
+}
+
+rule bd_php_rce_bticks_0 {
+  meta:
+    author = "roscoe skeens (defended.net)"
+    license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
+    description = "rce bticks"
+
+  strings:
+    $r1 = /`[ \t]{0,8}\$`/
+
+  condition:
+    $r1 and filesize < 512
+}
+
+rule bd_php_cback_xpath_0 {
+  meta:
+    author = "roscoe skeens (defended.net)"
+    license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
+    description = "cback xpath"
 
   strings:
     $s1 = "php:functionString"
@@ -74,11 +101,11 @@ rule bd_php_callback_xpath_0 {
     $s1
 }
 
-rule bd_php_callback_xslt_0 {
+rule bd_php_cback_xslt_0 {
   meta:
     author = "roscoe skeens (defended.net)"
     license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
-    description = "callback xslt"
+    description = "cback xslt"
 
   strings:
     $h1 = { 2D 3E [0-10] 72 65 67 69 73 74 65 72 50 48 50 46 75 6E 63 74 69 6F 6E 73 }

--- a/defended/exp/exp.yr
+++ b/defended/exp/exp.yr
@@ -1,0 +1,33 @@
+/*             __            __      __
+   __ _  ___ _/ /    _____ _/ /_____/ /
+  /    \/ _ `/ / |/|/ / _ `/ __/ __/ _ \
+ /_/_/_/\_,_/_/|__,__/\_,_/\__/\__/_//_/
+                            defended.net
+*/
+
+rule epx_php_addr_mask_0 {
+  meta:
+    author = "roscoe skeens (defended.net)"
+    license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
+    description = "addr mask"
+
+  strings:
+    $s1 = "0xfffffffffffff000"
+
+  condition:
+    $s1
+}
+
+rule epx_php_heap_groom_0 {
+  meta:
+    author = "roscoe skeens (defended.net)"
+    license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
+    description = "heap groom"
+
+  strings:
+    $s1 = "ZEND_DEBUG_BUILD"
+    $s2 = "0x60"
+
+  condition:
+    all of them
+}

--- a/defended/ioc/ioc.yr
+++ b/defended/ioc/ioc.yr
@@ -169,7 +169,7 @@ rule ioc_php_dropper_small_upload_0 {
     filesize < 1024
 }
 
-rule ioc_php_artifcat_sys_cfg_0 {
+rule ioc_php_artifact_sys_cfg_0 {
   meta:
     author = "roscoe skeens (defended.net)"
     license = "https://creativecommons.org/licenses/by-nc-sa/4.0"

--- a/defended/ioc/ioc.yr
+++ b/defended/ioc/ioc.yr
@@ -98,7 +98,7 @@ rule ioc_php_obf_concats_incr_0 {
   meta:
     author = "roscoe skeens (defended.net)"
     license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
-    description = "obf concats increments"
+    description = "obf concats incr"
 
   strings:
     $r1 = /(\$\w{,8}\+\+;){2}/
@@ -120,11 +120,11 @@ rule ioc_php_obf_concats_name_0 {
     $r1
 }
 
-rule ioc_php_obf_sglobals_scoped_0 {
+rule ioc_php_obf_scoped_sglobal_0 {
   meta:
     author = "roscoe skeens (defended.net)"
     license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
-    description = "obf super globals"
+    description = "obf scoped sglobal"
 
   strings:
     $h1 = { 24 5F 53 45 52 56 45 52 [0-10] 5B [0-10] 5F [0-8] 3A 3A }
@@ -133,17 +133,57 @@ rule ioc_php_obf_sglobals_scoped_0 {
     $h1
 }
 
-rule ioc_php_fget_ip_0 {
+rule ioc_php_ip_fget_0 {
   meta:
     author = "roscoe skeens (defended.net)"
     license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
-    description = "fget ip"
+    description = "ip fget"
 
   strings:
     $r1 = /file_get_contents\s{,4}\(\s{,4}"https?:\/\/(\d{1,3}\.){3}/
 
   condition:
     $r1
+}
+
+rule ioc_php_dropper_small_upload_0 {
+  meta:
+    author = "roscoe skeens (defended.net)"
+    license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
+    description = "dropper small upload"
+
+  strings:
+    $s1 = "$_POST"
+    $s2 = "$_GET"
+    $s3 = "$_REQUEST"
+    $s4 = "$_FILES"
+    $s5 = "<form" nocase
+    $s6 = "file_get_contents" nocase
+    $s7 = "file_put_contents" nocase
+    $s8 = "move_uploaded_file" nocase
+    $s9 = "fwrite" nocase
+
+  condition:
+    any of ($s1, $s2, $s3, $s4, $s5, $s6) and
+    any of ($s7, $s8, $s9) and
+    filesize < 1024
+}
+
+rule ioc_php_artifcat_sys_cfg_0 {
+  meta:
+    author = "roscoe skeens (defended.net)"
+    license = "https://creativecommons.org/licenses/by-nc-sa/4.0"
+    description = "artifcat sys cfg"
+
+  strings:
+    $s1 = "<?php"
+    $s2 = "/etc/passwd"
+    $s3 = "/etc/hosts"
+    $s4 = "/etc/named.conf"
+
+  condition:
+    $s1 in (0..8) and
+    any of ($s2, $s3, $s4)
 }
 
 rule ioc_js_obf_b64_redir_0 {


### PR DESCRIPTION
new: `epx_php_addr_mask_0`
new: `epx_php_heap_groom_0`
new: `bd_php_rce_bticks_0`
new: `bd_php_rce_cback_sglobal_0`
new: `ioc_php_artifact_sys_cfg_0`
new: `ioc_php_dropper_small_upload_0`

Introduces a new `exp` family is the starting point to represents exploit frameworks that use more advanced techniques such as manipulating memory. There is now also clearer `bd` classification with an `rce` category added.

Two new `ioc` categories have been added, `dropper` and `artifact`. The `artifact` category represents suspicious constants such as private system paths.